### PR TITLE
Add intersectAll utility and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -344,3 +344,43 @@ function buildQueryFilter(query?: Query) {
     isBranch: boolean,
   ) => Awaitable<boolean>;
 }
+
+class MemoryStore implements IStore {
+  private store = new Map<string, JValue>();
+
+  async get<T extends JValue>(key: string) {
+    return this.store.get(key) as T | undefined;
+  }
+
+  async set<T extends JValue>(key: string, value: T) {
+    this.store.set(key, value);
+  }
+
+  async del(key: string) {
+    this.store.delete(key);
+  }
+}
+
+export type TrieNode = Radix<MemoryStore>;
+
+export async function buildTrie(words: Iterable<string>): Promise<TrieNode> {
+  const trie = new Radix(new MemoryStore());
+  for (const w of words) {
+    await trie.set(w, w);
+  }
+  return trie;
+}
+
+export async function* intersectAll(
+  hay: Radix,
+  needle: Radix,
+): AsyncGenerator<[string, JValue], void, unknown> {
+  const emitted = new Set<string>();
+  for await (const [prefix] of needle.loop()) {
+    for await (const [key, value] of hay.loop({ prefix })) {
+      if (emitted.has(key)) continue;
+      emitted.add(key);
+      yield [key, value];
+    }
+  }
+}

--- a/src/intersect.test.ts
+++ b/src/intersect.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildTrie, intersectAll } from './index';
+
+function randomWord(len: number) {
+  let out = '';
+  for (let i = 0; i < len; i++) {
+    out += String.fromCharCode(97 + Math.floor(Math.random() * 26));
+  }
+  return out;
+}
+
+function randomWords(count: number, minLen: number, maxLen: number) {
+  const res: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const len = minLen + Math.floor(Math.random() * (maxLen - minLen + 1));
+    res.push(randomWord(len));
+  }
+  return res;
+}
+
+function naiveIntersect(qWords: string[], iWords: string[]) {
+  const result = new Set<string>();
+  for (const q of qWords) {
+    for (const i of iWords) {
+      if (q.startsWith(i)) {
+        result.add(q);
+        break;
+      }
+    }
+  }
+  return Array.from(result).sort();
+}
+
+describe('intersectAll', () => {
+  it('matches naive implementation for random tries', async () => {
+    for (let r = 0; r < 20; r++) {
+      const qWords = randomWords(20, 1, 4);
+      const iWords = randomWords(10, 1, 3);
+      const qTrie = await buildTrie(qWords);
+      const iTrie = await buildTrie(iWords);
+      const fast: string[] = [];
+      for await (const [k] of intersectAll(qTrie, iTrie)) fast.push(k);
+      fast.sort();
+      const slow = naiveIntersect(qWords, iWords);
+      expect(fast).toEqual(slow);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement `MemoryStore`, `buildTrie`, and `intersectAll` helpers
- add property-style test exercising `intersectAll`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684663a0ce848326b6544a322587b374